### PR TITLE
Create ultron.c

### DIFF
--- a/ultron.c
+++ b/ultron.c
@@ -1,0 +1,146 @@
+#include "hdf_device_desc.h"
+#include "hdf_log.h"
+#include "osal_mem.h"
+#include "osal_time.h"
+
+#define HDF_LOG_TAG custom_driver
+
+// Driver structure
+struct CustomDriver {
+    struct IDeviceIoService service;
+    OSAL_MUTEX mutex;
+    void *private_data;
+};
+
+// Initialize the driver
+static int32_t CustomDriverInit(struct HdfDeviceObject *device)
+{
+    struct CustomDriver *driver;
+    HDF_LOGI("Custom driver initializing");
+    
+    if (device == NULL) {
+        HDF_LOGE("Device object is null");
+        return HDF_ERR_INVALID_PARAM;
+    }
+
+    driver = (struct CustomDriver *)OsalMemCalloc(sizeof(struct CustomDriver));
+    if (driver == NULL) {
+        HDF_LOGE("Failed to allocate driver");
+        return HDF_ERR_MALLOC_FAIL;
+    }
+
+    // Initialize mutex
+    if (OsalMutexInit(&driver->mutex) != HDF_SUCCESS) {
+        HDF_LOGE("Failed to initialize mutex");
+        OsalMemFree(driver);
+        return HDF_FAILURE;
+    }
+
+    device->service = &driver->service;
+    return HDF_SUCCESS;
+}
+
+// Release driver resources
+static void CustomDriverRelease(struct HdfDeviceObject *device)
+{
+    struct CustomDriver *driver;
+    
+    if (device == NULL) {
+        return;
+    }
+
+    driver = (struct CustomDriver *)device->service;
+    if (driver != NULL) {
+        OsalMutexDestroy(&driver->mutex);
+        OsalMemFree(driver);
+    }
+}
+
+// Driver dispatch function
+static int32_t CustomDriverDispatch(
+    struct HdfDeviceIoService *service,
+    int32_t cmd,
+    struct HdfSBuf *data,
+    struct HdfSBuf *reply)
+{
+    struct CustomDriver *driver = CONTAINER_OF(
+        service, struct CustomDriver, service);
+
+    switch (cmd) {
+        case CUSTOM_CMD_GET_STATUS:
+            return HandleGetStatus(driver, reply);
+        case CUSTOM_CMD_SET_CONFIG:
+            return HandleSetConfig(driver, data);
+        default:
+            return HDF_ERR_NOT_SUPPORT;
+    }
+}
+
+// Command handlers
+static int32_t HandleGetStatus(struct CustomDriver *driver, struct HdfSBuf *reply)
+{
+    int32_t status = 0;
+    
+    if (OsalMutexLock(&driver->mutex) != HDF_SUCCESS) {
+        return HDF_FAILURE;
+    }
+    
+    // Get status logic here
+    
+    if (!HdfSbufWriteInt32(reply, status)) {
+        OsalMutexUnlock(&driver->mutex);
+        return HDF_FAILURE;
+    }
+    
+    OsalMutexUnlock(&driver->mutex);
+    return HDF_SUCCESS;
+}
+
+static int32_t HandleSetConfig(struct CustomDriver *driver, struct HdfSBuf *data)
+{
+    int32_t config;
+    
+    if (!HdfSbufReadInt32(data, &config)) {
+        return HDF_FAILURE;
+    }
+    
+    if (OsalMutexLock(&driver->mutex) != HDF_SUCCESS) {
+        return HDF_FAILURE;
+    }
+    
+    // Set config logic here
+    
+    OsalMutexUnlock(&driver->mutex);
+    return HDF_SUCCESS;
+}
+
+// Driver entry structure
+struct HdfDriverEntry g_customDriverEntry = {
+    .moduleVersion = 1,
+    .moduleName = "custom_driver",
+    .Bind = NULL,
+    .Init = CustomDriverInit,
+    .Release = CustomDriverRelease,
+};
+
+// Register driver entry
+HDF_INIT(g_customDriverEntry);
+
+// Device configuration descriptor
+static struct HdfDeviceObject *g_customDeviceObject;
+
+static struct IDeviceIoService g_customService = {
+    .Dispatch = CustomDriverDispatch,
+};
+
+// Device object creation
+int32_t CustomDriverBind(struct HdfDeviceObject *device)
+{
+    if (device == NULL) {
+        return HDF_ERR_INVALID_PARAM;
+    }
+
+    device->service = &g_customService;
+    g_customDeviceObject = device;
+    return HDF_SUCCESS;
+}


### PR DESCRIPTION
```c
#include "hdf_device_desc.h"
#include "hdf_log.h"
#include "osal_mem.h"
#include "osal_time.h"

#define HDF_LOG_TAG custom_driver

// Driver structure
struct CustomDriver {
    struct IDeviceIoService service;
    OSAL_MUTEX mutex;
    void *private_data;
};

// Initialize the driver
static int32_t CustomDriverInit(struct HdfDeviceObject *device)
{
    struct CustomDriver *driver;
    HDF_LOGI("Custom driver initializing");
    
    if (device == NULL) {
        HDF_LOGE("Device object is null");
        return HDF_ERR_INVALID_PARAM;
    }

    driver = (struct CustomDriver *)OsalMemCalloc(sizeof(struct CustomDriver));
    if (driver == NULL) {
        HDF_LOGE("Failed to allocate driver");
        return HDF_ERR_MALLOC_FAIL;
    }

    // Initialize mutex
    if (OsalMutexInit(&driver->mutex) != HDF_SUCCESS) {
        HDF_LOGE("Failed to initialize mutex");
        OsalMemFree(driver);
        return HDF_FAILURE;
    }

    device->service = &driver->service;
    return HDF_SUCCESS;
}

// Release driver resources
static void CustomDriverRelease(struct HdfDeviceObject *device)
{
    struct CustomDriver *driver;
    
    if (device == NULL) {
        return;
    }

    driver = (struct CustomDriver *)device->service;
    if (driver != NULL) {
        OsalMutexDestroy(&driver->mutex);
        OsalMemFree(driver);
    }
}

// Driver dispatch function
static int32_t CustomDriverDispatch(
    struct HdfDeviceIoService *service,
    int32_t cmd,
    struct HdfSBuf *data,
    struct HdfSBuf *reply)
{
    struct CustomDriver *driver = CONTAINER_OF(
        service, struct CustomDriver, service);

    switch (cmd) {
        case CUSTOM_CMD_GET_STATUS:
            return HandleGetStatus(driver, reply);
        case CUSTOM_CMD_SET_CONFIG:
            return HandleSetConfig(driver, data);
        default:
            return HDF_ERR_NOT_SUPPORT;
    }
}

// Command handlers
static int32_t HandleGetStatus(struct CustomDriver *driver, struct HdfSBuf *reply)
{
    int32_t status = 0;
    
    if (OsalMutexLock(&driver->mutex) != HDF_SUCCESS) {
        return HDF_FAILURE;
    }
    
    // Get status logic here
    
    if (!HdfSbufWriteInt32(reply, status)) {
        OsalMutexUnlock(&driver->mutex);
        return HDF_FAILURE;
    }
    
    OsalMutexUnlock(&driver->mutex);
    return HDF_SUCCESS;
}

static int32_t HandleSetConfig(struct CustomDriver *driver, struct HdfSBuf *data)
{
    int32_t config;
    
    if (!HdfSbufReadInt32(data, &config)) {
        return HDF_FAILURE;
    }
    
    if (OsalMutexLock(&driver->mutex) != HDF_SUCCESS) {
        return HDF_FAILURE;
    }
    
    // Set config logic here
    
    OsalMutexUnlock(&driver->mutex);
    return HDF_SUCCESS;
}

// Driver entry structure
struct HdfDriverEntry g_customDriverEntry = {
    .moduleVersion = 1,
    .moduleName = "custom_driver",
    .Bind = NULL,
    .Init = CustomDriverInit,
    .Release = CustomDriverRelease,
};

// Register driver entry
HDF_INIT(g_customDriverEntry);

// Device configuration descriptor
static struct HdfDeviceObject *g_customDeviceObject;

static struct IDeviceIoService g_customService = {
    .Dispatch = CustomDriverDispatch,
};

// Device object creation
int32_t CustomDriverBind(struct HdfDeviceObject *device)
{
    if (device == NULL) {
        return HDF_ERR_INVALID_PARAM;
    }

    device->service = &g_customService;
    g_customDeviceObject = device;
    return HDF_SUCCESS;
}
```