### PR TITLE
Create README.md

### DIFF
--- a/ULTRON/README.md
+++ b/ULTRON/README.md
@@ -1,0 +1,22 @@
+Let me break down the RAM sizing in the DDR5 controller I provided:
+
+In the implementation:
+- Address Width = 32 bits
+- Data Width = 64 bits (standard DDR5 width)
+- Address Space Breakdown:
+  - Row Address: 18 bits (row_addr[17:0])
+  - Column Address: 10 bits (col_addr[9:0])
+  - Bank Address: 2 bits
+  - Bank Group: 2 bits
+
+Total Addressable Space Calculation:
+- 2^18 (rows) × 2^10 (columns) × 2^2 (banks) × 2^2 (bank groups) = 2^32 addresses
+- Each address accesses 64 bits (8 bytes)
+- Therefore: 2^32 × 8 = 32GB of addressable memory
+
+However, this controller can be modified for different capacities by adjusting:
+1. ADDR_WIDTH parameter
+2. Row/Column address bits
+3. Number of banks/bank groups
+
+Would you like me to modify the design for a different RAM capacity or explain the addressing scheme in more detail?


### PR DESCRIPTION
```markdown
Let me break down the RAM sizing in the DDR5 controller I provided:

In the implementation:
- Address Width = 32 bits
- Data Width = 64 bits (standard DDR5 width)
- Address Space Breakdown:
  - Row Address: 18 bits (row_addr[17:0])
  - Column Address: 10 bits (col_addr[9:0])
  - Bank Address: 2 bits
  - Bank Group: 2 bits

Total Addressable Space Calculation:
- 2^18 (rows) × 2^10 (columns) × 2^2 (banks) × 2^2 (bank groups) = 2^32 addresses
- Each address accesses 64 bits (8 bytes)
- Therefore: 2^32 × 8 = 32GB of addressable memory

However, this controller can be modified for different capacities by adjusting:
1. ADDR_WIDTH parameter
2. Row/Column address bits
3. Number of banks/bank groups

Would you like me to modify the design for a different RAM capacity or explain the addressing scheme in more detail?
```